### PR TITLE
Fix the configuration and some other minor things.

### DIFF
--- a/pybert/pybert.py
+++ b/pybert/pybert.py
@@ -610,6 +610,8 @@ class PyBERT(HasTraits):
         super(PyBERT, self).__init__()
 
         self.log("Started.")
+        if self.debug:
+            self.log("Debug Mode Enabled.")
 
         if run_simulation:
             # Running the simulation will fill in the required data structure.

--- a/pybert/pybert_cfg.py
+++ b/pybert/pybert_cfg.py
@@ -45,6 +45,7 @@ class PyBertCfg:
         self.use_ch_file = the_PyBERT.use_ch_file
         self.ch_file = the_PyBERT.ch_file
         self.impulse_length = the_PyBERT.impulse_length
+        self.f_step = the_PyBERT.f_step
         self.Rdc = the_PyBERT.Rdc
         self.w0 = the_PyBERT.w0
         self.R0 = the_PyBERT.R0

--- a/pybert/pybert_cfg.py
+++ b/pybert/pybert_cfg.py
@@ -65,6 +65,9 @@ class PyBertCfg:
         for tap in the_PyBERT.tx_taps:
             tx_taps.append((tap.enabled, tap.value))
         self.tx_taps = tx_taps
+        self.tx_tap_tuners = []
+        for tap in the_PyBERT.tx_tap_tuners:
+            self.tx_tap_tuners.append((tap.enabled, tap.value))        
         self.tx_use_ami = the_PyBERT.tx_use_ami
         self.tx_use_getwave = the_PyBERT.tx_use_getwave
         self.tx_ami_file = the_PyBERT.tx_ami_file
@@ -81,6 +84,8 @@ class PyBertCfg:
         self.peak_mag = the_PyBERT.peak_mag
         self.ctle_offset = the_PyBERT.ctle_offset
         self.ctle_mode = the_PyBERT.ctle_mode
+        self.ctle_mode_tune = the_PyBERT.ctle_mode_tune
+        self.ctle_offset_tune = the_PyBERT.ctle_offset_tune
         self.rx_use_ami = the_PyBERT.rx_use_ami
         self.rx_use_getwave = the_PyBERT.rx_use_getwave
         self.rx_ami_file = the_PyBERT.rx_ami_file
@@ -88,6 +93,7 @@ class PyBertCfg:
 
         # DFE
         self.use_dfe = the_PyBERT.use_dfe
+        self.use_dfe_tune = the_PyBERT.use_dfe_tune
         self.sum_ideal = the_PyBERT.sum_ideal
         self.decision_scaler = the_PyBERT.decision_scaler
         self.gain = the_PyBERT.gain

--- a/pybert/pybert_view.py
+++ b/pybert/pybert_view.py
@@ -68,7 +68,7 @@ class MyHandler(Handler):
         if dlg.open() == OK:
             the_PyBertCfg = PyBertCfg(the_pybert)
             try:
-                with open(dlg.path, "wt") as the_file:
+                with open(dlg.path, "wb") as the_file:
                     pickle.dump(the_PyBertCfg, the_file)
                 the_pybert.cfg_file = dlg.path
             except Exception as err:
@@ -81,7 +81,7 @@ class MyHandler(Handler):
         dlg = FileDialog(action="open", wildcard="*.pybert_cfg", default_path=the_pybert.cfg_file)
         if dlg.open() == OK:
             try:
-                with open(dlg.path, "rt") as the_file:
+                with open(dlg.path, "rb") as the_file:
                     the_PyBertCfg = pickle.load(the_file)
                 if not isinstance(the_PyBertCfg, PyBertCfg):
                     raise Exception("The data structure read in is NOT of type: PyBertCfg!")

--- a/pybert/pybert_view.py
+++ b/pybert/pybert_view.py
@@ -631,7 +631,7 @@ traits_view = View(
                             ),
                         ),
                         HGroup(
-                            Item(name="use_dfe_tune", label="Use DFE.", tooltip="Include ideal DFE in optimization."),
+                            Item(name="use_dfe_tune", label="Use DFE:", tooltip="Include ideal DFE in optimization."),
                             Item(name="n_taps_tune", label="Taps", tooltip="Number of DFE taps."),
                         ),
                     ),

--- a/pybert/pybert_view.py
+++ b/pybert/pybert_view.py
@@ -87,11 +87,13 @@ class MyHandler(Handler):
                     raise Exception("The data structure read in is NOT of type: PyBertCfg!")
                 for prop, value in vars(the_PyBertCfg).items():
                     if prop == "tx_taps":
-                        i = 0
-                        for (enabled, val) in value:
-                            setattr(the_pybert.tx_taps[i], "enabled", enabled)
-                            setattr(the_pybert.tx_taps[i], "value", val)
-                            i += 1
+                        for count, (enabled, val) in enumerate(value):
+                            setattr(the_pybert.tx_taps[count], "enabled", enabled)
+                            setattr(the_pybert.tx_taps[count], "value", val)
+                    elif prop == "tx_tap_tuners":
+                        for count, (enabled, val) in enumerate(value):
+                            setattr(the_pybert.tx_tap_tuners[count], "enabled", enabled)
+                            setattr(the_pybert.tx_tap_tuners[count], "value", val)
                     else:
                         setattr(the_pybert, prop, value)
                 the_pybert.cfg_file = dlg.path


### PR DESCRIPTION
- Fixes #51 - Python 3 requires an explicit binary flag when opening a file for pickling.  Python 2 just assumed it.
- Fixes #43 - Added tuned values to cfg, Added f_step and corrected "Use DFE." to "Use DFE:".
- If debug mode is enabled; it's logged when PyBERT is created.

Some future thoughts, we should change to a true configuration file type and binary type to save data.  Pickling is okay when between processes but since we are saving or loading configuration; it has some security risks.