### PR TITLE
Fix a configuration issue where the modulation scheme wouldn't serialize.

### DIFF
--- a/pybert/pybert_cfg.py
+++ b/pybert/pybert_cfg.py
@@ -73,6 +73,7 @@ class PyBertCfg:
         self.tx_use_getwave = the_PyBERT.tx_use_getwave
         self.tx_ami_file = the_PyBERT.tx_ami_file
         self.tx_dll_file = the_PyBERT.tx_dll_file
+        self.tx_ibis_file = the_PyBERT.tx_ibis_file
 
         # Rx
         self.rin = the_PyBERT.rin
@@ -92,6 +93,7 @@ class PyBertCfg:
         self.rx_use_getwave = the_PyBERT.rx_use_getwave
         self.rx_ami_file = the_PyBERT.rx_ami_file
         self.rx_dll_file = the_PyBERT.rx_dll_file
+        self.rx_ibis_file = the_PyBERT.rx_ibis_file
 
         # DFE
         self.use_dfe = the_PyBERT.use_dfe

--- a/pybert/pybert_cfg.py
+++ b/pybert/pybert_cfg.py
@@ -35,7 +35,7 @@ class PyBertCfg:
         self.pattern_len = the_PyBERT.pattern_len
         self.nspb = the_PyBERT.nspb
         self.eye_bits = the_PyBERT.eye_bits
-        self.mod_type = the_PyBERT.mod_type
+        self.mod_type = list(the_PyBERT.mod_type)
         self.num_sweeps = the_PyBERT.num_sweeps
         self.sweep_num = the_PyBERT.sweep_num
         self.sweep_aves = the_PyBERT.sweep_aves

--- a/pybert/pybert_cfg.py
+++ b/pybert/pybert_cfg.py
@@ -35,7 +35,7 @@ class PyBertCfg:
         self.pattern_len = the_PyBERT.pattern_len
         self.nspb = the_PyBERT.nspb
         self.eye_bits = the_PyBERT.eye_bits
-        self.mod_type = list(the_PyBERT.mod_type)
+        self.mod_type = list(the_PyBERT.mod_type) # Get the underlying list from the TraitListObject
         self.num_sweeps = the_PyBERT.num_sweeps
         self.sweep_num = the_PyBERT.sweep_num
         self.sweep_aves = the_PyBERT.sweep_aves

--- a/pybert/pybert_view.py
+++ b/pybert/pybert_view.py
@@ -89,7 +89,7 @@ class MyHandler(Handler):
         dlg = FileDialog(action="open", wildcard="*.pybert_cfg", default_path=the_pybert.cfg_file)
         if dlg.open() == OK:
             try:
-                with open(dlg.path, "rb") as the_file:
+                with open(dlg.path, "r") as the_file:
                     the_PyBertCfg = yaml.load(the_file, Loader=yaml.Loader)
                 if not isinstance(the_PyBertCfg, PyBertCfg):
                     raise Exception("The data structure read in is NOT of type: PyBertCfg!")

--- a/pybert/pybert_view.py
+++ b/pybert/pybert_view.py
@@ -66,16 +66,15 @@ class MyHandler(Handler):
             self.run_sim_thread.stop()
 
     def do_save_cfg(self, info):
-        """Pickle out the current configuration."""
+        """Save out the current configuration as YAML."""
         the_pybert = info.object
         dlg = FileDialog(action="save as", wildcard="*.pybert_cfg", default_path=the_pybert.cfg_file)
         if dlg.open() == OK:
             the_PyBertCfg = PyBertCfg(the_pybert)
             try:
-                with open(dlg.path, "wb") as the_file:
+                with open(dlg.path, "w") as the_file:
                     # Grab all the instance variables from the_PyBertCfg
-                    # yaml.dump(the_PyBertCfg, the_file)
-                    pickle.dump(the_PyBertCfg, the_file)
+                    yaml.dump(the_PyBertCfg, the_file)
                 the_pybert.cfg_file = dlg.path
                 the_pybert.log(f"Configuration saved to {the_pybert.cfg_file}")
             except Exception as err:
@@ -85,14 +84,13 @@ class MyHandler(Handler):
                 )
 
     def do_load_cfg(self, info):
-        """Read in the pickled configuration."""
+        """Read in the configuration."""
         the_pybert = info.object
         dlg = FileDialog(action="open", wildcard="*.pybert_cfg", default_path=the_pybert.cfg_file)
         if dlg.open() == OK:
             try:
                 with open(dlg.path, "rb") as the_file:
-                    # the_PyBertCfg = yaml.load(the_file, Loader=yaml.Loader)
-                    the_PyBertCfg = pickle.load(the_file)
+                    the_PyBertCfg = yaml.load(the_file, Loader=yaml.Loader)
                 if not isinstance(the_PyBertCfg, PyBertCfg):
                     raise Exception("The data structure read in is NOT of type: PyBertCfg!")
                 for prop, value in vars(the_PyBertCfg).items():


### PR DESCRIPTION
Fixes #95.  Basically, pyyaml didn't know how to serialize or deserialize the List Trait.  This reverts the change to pickle back to pyyaml.