### PR TITLE
fix: use pytest fixtures and remove version test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ profile = "black"
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-vv"
+addopts = "-vv --durations=3"
 xfail_strict=true
 
 [tool.pylint.master]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Shared fixtures across the pybert testing infrastructure."""
+
+import pytest
+
+from pybert.pybert import PyBERT
+
+
+@pytest.fixture(scope="module")
+def dut():
+    """Return an initialized pybert object that has already one simulation."""
+    yield PyBERT(gui=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,5 +7,5 @@ from pybert.pybert import PyBERT
 
 @pytest.fixture(scope="module")
 def dut():
-    """Return an initialized pybert object that has already one simulation."""
+    """Return an initialized pybert object that has already run the initial simulation."""
     yield PyBERT(gui=False)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,60 +1,54 @@
 """Run some basic tests on a PyBERT instance."""
 import numpy as np
-
-import pybert
-from pybert.pybert import PyBERT
+import pytest
 
 
+@pytest.mark.usefixtures("dut")
 class TestBasic(object):
     """Basic tests of a properly initialized PyBERT."""
 
-    dut = PyBERT(gui=False)
-
-    def test_version(self):
-        assert pybert.__version__ == "3.5.8"
-
-    def test_status(self):
+    def test_status(self, dut):
         """Test post-simulation status."""
-        assert self.dut.status == "Ready.", "Status not 'Ready.'!"
+        assert dut.status == "Ready.", "Status not 'Ready.'!"
 
-    def test_perf(self):
+    def test_perf(self, dut):
         """Test simulation performance."""
-        assert self.dut.total_perf > (1e6 / 60), "Performance dropped below 1 Msmpls/min.!"
+        assert dut.total_perf > (1e6 / 60), "Performance dropped below 1 Msmpls/min.!"
 
-    def test_ber(self):
+    def test_ber(self, dut):
         """Test simulation bit errors."""
-        assert not self.dut.bit_errs, "Bit errors detected!"
+        assert not dut.bit_errs, "Bit errors detected!"
 
-    def test_dly(self):
+    def test_dly(self, dut):
         """Test channel delay."""
-        assert self.dut.chnl_dly > 1e-9 and self.dut.chnl_dly < 10e-9, "Channel delay is out of range!"
+        assert dut.chnl_dly > 1e-9 and dut.chnl_dly < 10e-9, "Channel delay is out of range!"
 
-    def test_isi(self):
+    def test_isi(self, dut):
         """Test ISI portion of jitter."""
-        assert self.dut.isi_dfe < 50e-12, "ISI is too high!"
+        assert dut.isi_dfe < 50e-12, "ISI is too high!"
 
-    def test_dcd(self):
+    def test_dcd(self, dut):
         """Test DCD portion of jitter."""
-        assert self.dut.dcd_dfe < 20e-12, "DCD is too high!"
+        assert dut.dcd_dfe < 20e-12, "DCD is too high!"
 
-    def test_pj(self):
+    def test_pj(self, dut):
         """Test periodic portion of jitter."""
-        assert self.dut.pj_dfe < 20e-12, "Periodic jitter is too high!"
+        assert dut.pj_dfe < 20e-12, "Periodic jitter is too high!"
 
-    def test_rj(self):
+    def test_rj(self, dut):
         """Test random portion of jitter."""
-        assert self.dut.rj_dfe < 20e-12, "Random jitter is too high!"
+        assert dut.rj_dfe < 20e-12, "Random jitter is too high!"
 
-    def test_lock(self):
+    def test_lock(self, dut):
         """Test CDR lock, by ensuring that last 20% of locked indication vector
         is all True."""
-        _lockeds = self.dut.lockeds
+        _lockeds = dut.lockeds
         assert all(_lockeds[4 * len(_lockeds) // 5 :]), "CDR lock is unstable!"
 
-    def test_adapt(self):
+    def test_adapt(self, dut):
         """Test DFE lock, by ensuring that last 20% of all coefficient vectors
         are stable to within +/-20% of their mean."""
-        _weights = self.dut.adaptation  # rows = step; cols = tap
+        _weights = dut.adaptation  # rows = step; cols = tap
         _ws = np.array(list(zip(*_weights[4 * len(_weights) // 5 :])))  # zip(*x) = unzip(x)
         _means = list(map(lambda xs: sum(xs) / len(xs), _ws))
         assert all(


### PR DESCRIPTION
As we add more tests, we might add -n auto to addopts = "-vv --durations=3" which will spilt up tests across processes which will make all tests run quicker since they are in parallel and not serial. This has the drawback that individual performance will be affected which might require testing performance in a different way.

This does add `--durations=3` which shows the three slowest things from running the unit tests.