### PR TITLE
Change ButtonHandler to MenuBar

### DIFF
--- a/src/pybert/cli.py
+++ b/src/pybert/cli.py
@@ -34,9 +34,9 @@ def cli(ctx, config_file, results):
 def sim(config_file, results):
     """Run a simulation without opening the GUI.
 
-    Will load the CONFIG_FILE from the given filepath, run the simulation and
-    then save the results into a file with the same name but a different
-    extension as the configuration file.
+    Will load the CONFIG_FILE from the given filepath, run the
+    simulation and then save the results into a file with the same name
+    but a different extension as the configuration file.
     """
     pybert = PyBERT(run_simulation=False, gui=False)
     pybert.load_configuration(config_file)

--- a/src/pybert/gui/view.py
+++ b/src/pybert/gui/view.py
@@ -897,7 +897,7 @@ traits_view = View(
         ),
         Menu(
             Action(
-                name="Toggle Debug Mode",
+                name="Debug Mode",
                 action="toggle_debug_clicked",
                 accelerator="Ctrl+`",
                 style="toggle",

--- a/src/pybert/gui/view.py
+++ b/src/pybert/gui/view.py
@@ -264,6 +264,7 @@ traits_view = View(
                     Item(
                         name="thresh",
                         label="Pj Threshold (sigma)",
+                        tooltip="Threshold for identifying periodic jitter spectral elements. (sigma)",
                     ),
                     Item(
                         name="impulse_length",

--- a/src/pybert/gui/view.py
+++ b/src/pybert/gui/view.py
@@ -6,13 +6,15 @@ Original date:   August 24, 2014 (Copied from pybert.py, as part of a major code
 
 Copyright (c) 2014 David Banas; all rights reserved World wide.
 """
+import sys
+import webbrowser
 from pathlib import Path
 from threading import Thread
 
-from pyface.api import OK, FileDialog
+from pyface.api import OK, FileDialog, MessageDialog
 from pyface.image_resource import ImageResource
 from traits.api import Instance
-from traitsui.api import (
+from traitsui.api import (  # CloseAction,
     Action,
     CheckListEditor,
     FileEditor,
@@ -20,7 +22,11 @@ from traitsui.api import (
     Handler,
     HGroup,
     Item,
+    Menu,
+    MenuBar,
+    NoButtons,
     ObjectColumn,
+    Separator,
     TableEditor,
     TextEditor,
     VGroup,
@@ -29,6 +35,7 @@ from traitsui.api import (
 )
 
 from enable.component_editor import ComponentEditor
+from pybert import __authors__, __copy__, __date__, __version__
 from pybert.configuration import CONFIG_LOAD_WILDCARD, CONFIG_SAVE_WILDCARD
 from pybert.models.bert import my_run_sweeps
 from pybert.results import RESULTS_FILEDIALOG_WILDCARD
@@ -65,6 +72,22 @@ class MyHandler(Handler):
             self.run_sim_thread.stop()
 
     def do_save_cfg(self, info):
+        """Save the configuration.
+
+        If no config file is set, use the `self.do_save_cfg_as()` method to prompt the user.
+
+        Args:
+            info: When an action is clicked, it passes the whole trait instance to this function.
+        """
+        # pylint: disable=no-self-use
+        pybert = info.object
+        configuration_file = Path(pybert.cfg_file)
+        if pybert.cfg_file and configuration_file.exists():
+            pybert.save_configuration(configuration_file)
+        else:  # A configuration file hasn't been set yet so use the save-as method
+            self.do_save_cfg_as(info)
+
+    def do_save_cfg_as(self, info):
         """Prompt the user to choose where to save the config and save it.
 
         Args:
@@ -132,16 +155,37 @@ class MyHandler(Handler):
         pybert = info.object
         pybert.clear_reference_from_plots()
 
+    def toggle_debug_clicked(self, info):
+        """Toggle whether debug mode is enabled or not."""
+        # pylint: disable=no-self-use
+        info.object.debug = not info.object.debug
 
-# These are the "globally applicable" buttons referred to in pybert.py,
-# just above the button definitions (approx. line 580).
-run_sim = Action(name="Run", action="do_run_simulation")
-stop_sim = Action(name="Stop", action="do_stop_simulation")
-save_data = Action(name="Save Results", action="do_save_data")
-load_data = Action(name="Load Results", action="do_load_data")
-clear_data = Action(name="Clear Reference", action="do_clear_data")
-save_cfg = Action(name="Save Config.", action="do_save_cfg")
-load_cfg = Action(name="Load Config.", action="do_load_cfg")
+    def getting_started_clicked(self, info):
+        """Open up Pybert's wiki."""
+        # pylint: disable=no-self-use,unused-argument
+        webbrowser.open("https://github.com/capn-freako/PyBERT/wiki")
+
+    def show_about_clicked(self, info):
+        """Open a dialog and show the user the about info."""
+        # pylint: disable=no-self-use,unused-argument
+        dialog = MessageDialog(
+            title="About Pybert",
+            message=f"PyBERT v{__version__} - a serial communication link design tool, written in Python.",
+            informative=(
+                f"{__authors__}<BR>\n" f"{__date__}<BR><BR>\n\n" f"{__copy__};<BR>\n" "All rights reserved World wide."
+            ),
+            severity="information",
+        )
+        dialog.open()
+
+    def close_app(self, info):
+        """Close the app.
+
+        Can't use CloseAction until https://github.com/enthought/traitsui/issues/1442 is resolved.
+        """
+        # pylint: disable=no-self-use,unused-argument
+        sys.exit(0)
+
 
 # Main window layout definition.
 traits_view = View(
@@ -220,7 +264,6 @@ traits_view = View(
                     Item(
                         name="thresh",
                         label="Pj Threshold (sigma)",
-                        tooltip="Threshold for identifying periodic jitter spectral elements. (sigma)",
                     ),
                     Item(
                         name="impulse_length",
@@ -825,7 +868,6 @@ traits_view = View(
         ),
         Group(  # Help
             Group(
-                Item("ident", style="readonly", show_label=False),
                 Item("perf_info", style="readonly", show_label=False),
                 label="About",
             ),
@@ -841,7 +883,40 @@ traits_view = View(
     ),
     resizable=True,
     handler=MyHandler(),
-    buttons=[run_sim, save_cfg, load_cfg, save_data, load_data, clear_data],
+    menubar=MenuBar(
+        Menu(
+            Action(name="Load Config.", action="do_load_cfg", accelerator="Ctrl+O"),
+            Action(name="Load Results", action="do_load_data"),
+            Separator(),
+            Action(name="Save Config.", action="do_save_cfg", accelerator="Ctrl+S"),
+            Action(name="Save Config. As...", action="do_save_cfg_as", accelerator="Ctrl+Shift+S"),
+            Action(name="Save Results", action="do_save_data"),
+            Separator(),
+            Action(name="&Quit", action="close_app", accelerator="Ctrl+Q"),
+            name="&File",
+        ),
+        Menu(
+            Action(
+                name="Toggle Debug Mode",
+                action="toggle_debug_clicked",
+                accelerator="Ctrl+`",
+                style="toggle",
+                checked_when="debug == True",
+            ),
+            Action(
+                name="Clear Loaded Waveform(s)",
+                action="do_clear_data",
+            ),
+            name="&View",
+        ),
+        Menu(Action(name="Run", action="do_run_simulation", accelerator="Ctrl+R"), name="&Simulation"),
+        Menu(
+            Action(name="Getting Started", action="getting_started_clicked"),
+            Action(name="&About", action="show_about_clicked"),
+            name="&Help",
+        ),
+    ),
+    buttons=NoButtons,
     statusbar="status_str",
     title="PyBERT",
     # width=0.95,

--- a/src/pybert/gui/view.py
+++ b/src/pybert/gui/view.py
@@ -866,16 +866,16 @@ traits_view = View(
             label="Jitter",
             id="jitter",
         ),
-        Group(  # Help
+        Group(  # Info
             Group(
                 Item("perf_info", style="readonly", show_label=False),
-                label="About",
+                label="Performance",
             ),
-            Group(Item("instructions", style="readonly", show_label=False), label="Guide"),
+            Group(Item("instructions", style="readonly", show_label=False), label="User's Guide"),
             Group(Item("console_log", style="readonly", show_label=False), label="Console", id="console"),
             layout="tabbed",
-            label="Help",
-            id="help",
+            label="Info",
+            id="info",
         ),
         layout="tabbed",
         springy=True,

--- a/src/pybert/gui/view.py
+++ b/src/pybert/gui/view.py
@@ -892,7 +892,8 @@ traits_view = View(
             Action(name="Save Config. As...", action="do_save_cfg_as", accelerator="Ctrl+Shift+S"),
             Action(name="Save Results", action="do_save_data"),
             Separator(),
-            Action(name="&Quit", action="close_app", accelerator="Ctrl+Q"),
+            Action(name="&Quit", action="close_app", accelerator="Ctrl+Q"),  # CloseAction()
+            id="file",
             name="&File",
         ),
         Menu(
@@ -904,15 +905,17 @@ traits_view = View(
                 checked_when="debug == True",
             ),
             Action(
-                name="Clear Loaded Waveform(s)",
+                name="Clear Loaded Waveforms",
                 action="do_clear_data",
             ),
+            id="view",
             name="&View",
         ),
-        Menu(Action(name="Run", action="do_run_simulation", accelerator="Ctrl+R"), name="&Simulation"),
+        Menu(Action(name="Run", action="do_run_simulation", accelerator="Ctrl+R"), id="simulation", name="Simulation"),
         Menu(
             Action(name="Getting Started", action="getting_started_clicked"),
             Action(name="&About", action="show_about_clicked"),
+            id="help",
             name="&Help",
         ),
     ),

--- a/src/pybert/gui/view.py
+++ b/src/pybert/gui/view.py
@@ -122,6 +122,16 @@ class MyHandler(Handler):
         if dialog.open() == OK:
             pybert.load_results(Path(dialog.path))
 
+    def do_clear_data(self, info):
+        """If any reference or prior results has been loaded, clear it.
+
+        Args:
+            info: When an action is clicked, it passes the whole trait instance to this function.
+        """
+        # pylint: disable=no-self-use
+        pybert = info.object
+        pybert.clear_reference_from_plots()
+
 
 # These are the "globally applicable" buttons referred to in pybert.py,
 # just above the button definitions (approx. line 580).
@@ -129,6 +139,7 @@ run_sim = Action(name="Run", action="do_run_simulation")
 stop_sim = Action(name="Stop", action="do_stop_simulation")
 save_data = Action(name="Save Results", action="do_save_data")
 load_data = Action(name="Load Results", action="do_load_data")
+clear_data = Action(name="Clear Reference", action="do_clear_data")
 save_cfg = Action(name="Save Config.", action="do_save_cfg")
 load_cfg = Action(name="Load Config.", action="do_load_cfg")
 
@@ -830,7 +841,7 @@ traits_view = View(
     ),
     resizable=True,
     handler=MyHandler(),
-    buttons=[run_sim, save_cfg, load_cfg, save_data, load_data],
+    buttons=[run_sim, save_cfg, load_cfg, save_data, load_data, clear_data],
     statusbar="status_str",
     title="PyBERT",
     # width=0.95,

--- a/src/pybert/pybert.py
+++ b/src/pybert/pybert.py
@@ -1740,6 +1740,24 @@ Try to keep Nbits & EyeBits > 10 * 2^n, where `n` comes from `PRBS-n`.",
             self.log("Failed to save results to file. See the console for more detail.")
             self.log(str(exp))
 
+    def clear_reference_from_plots(self):
+        """If any plots have ref in the name, delete them and then regenerate the plots.
+
+        If we don't actually delete any data, skip regenerating the plots.
+        """
+        atleast_one_reference_removed = False
+
+        for reference_plot in self.plotdata.list_data():
+            if "ref" in reference_plot:
+                try:
+                    atleast_one_reference_removed = True
+                    self.plotdata.del_data(reference_plot)
+                except KeyError:
+                    pass
+
+        if atleast_one_reference_removed:
+            make_plots(self, n_dfe_taps=gNtaps)
+
     def log_information(self):
         """Log the system information."""
         self.log(f"System: {platform.system()} {platform.release()}")

--- a/src/pybert/pybert.py
+++ b/src/pybert/pybert.py
@@ -539,15 +539,6 @@ class PyBERT(HasTraits):
 
     # About
     perf_info = Property(String, depends_on=["total_perf"])
-    ident = String(
-        "<H1>PyBERT v{} - a serial communication link design tool, written in Python.</H1>\n\n \
-    {}<BR>\n \
-    {}<BR><BR>\n\n \
-    {};<BR>\n \
-    All rights reserved World wide.".format(
-            VERSION, AUTHORS, DATE, COPY
-        )
-    )
 
     # Help
     instructions = help_str

--- a/src/pybert/pybert.py
+++ b/src/pybert/pybert.py
@@ -606,11 +606,11 @@ class PyBERT(HasTraits):
         """Log a message to the console and, optionally, to terminal and/or
         pop-up dialog."""
         _msg = msg.strip()
-        txt = f"\n[{datetime.now()}]: PyBERT: {_msg}\n"
+        txt = f"[{datetime.now()}]: PyBERT: {_msg}"
         if self.debug:
             ## In case PyBERT crashes, before we can read this in its `Console` tab:
             print(txt, flush=True)
-        self.console_log += txt
+        self.console_log += txt + "\n"
         if exception:
             raise exception
         if alert and self.GUI:

--- a/src/pybert/results.py
+++ b/src/pybert/results.py
@@ -53,7 +53,7 @@ class PyBertData:
         "ctle_out_H",
         "dfe_out_H",
         "tx_out",
-        "rx_in",
+        # "rx_in", See Issue #111.  Comment out for now to remove error.
     ]
 
     def __init__(self, the_PyBERT, date_created: str, version: str):

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1,5 +1,4 @@
 """Unit test coverage to make sure that the added cli commands function like the gui."""
-import logging
 
 from click.testing import CliRunner
 


### PR DESCRIPTION
This PR closes #112 and closes #113 by making two changes to the user interface.

### Adds
- It adds a button to be able to clear any waveforms that are loaded by the user instead of requiring them to close/re-open the GUI to clear them. 
- It adds keyboard short cuts so that you can run, open, save quickly in the GUI.  The full list of short cuts:
    - Run "Ctrl + R"
    - Quit "Ctrl + Q"
    - Open Config "Ctrl + O"
    - Save Config "Ctrl + S"
    - Save Config As "Ctrl + Shift + S"
    - Toggle Debug Mode "Ctrl + `"

### Changes
- The button handler at the bottom apparently doesn't support the shortcuts or accelerators as traitsui calls them.  Only the menuBar does so this moves the buttons from the bottom to the top but are still globally accessible.
- Removes the double newline in the debug console.
- Renames the last tab from "help" to "Info" since the help and about info are on the menubar.
- When the user clicks getting started, it opens a web browser to our wiki!

### Notes
-  OS X does special things when menus have certain names like about and quit are moved under the apple menu instead of under file and help like in windows.
-  CloseAction is broken in traitsui so we made our own.
- Traitsui doesn't honor order in the menuBar like it should.

OS X
<img width="421" alt="Screen Shot 2022-12-08 at 9 05 54 PM" src="https://user-images.githubusercontent.com/14203439/206608903-f17b6b5c-e53f-4e76-8e75-165d253c9cf7.png">
Windows 10
![image](https://user-images.githubusercontent.com/14203439/206610074-cac168ea-4080-4e32-afc4-727a986021c2.png)

