### PR TITLE
122 derive project version from a single source

### DIFF
--- a/conda.recipe/pybert/meta.yaml
+++ b/conda.recipe/pybert/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "pybert" %}
-{% set version = "4.1.0" %}
+{% set pyproject = load_file_data('../../pyproject.toml', from_recipe_dir=true, recipe_dir="conda.recipe/pybert") %}
+{% set version = pyproject.get('project', {}).get('version') %}
 
 package:
   version: '{{ version }}'
@@ -9,8 +10,7 @@ source:
   path: ../../
 
 build:
-  number: 5
-  # noarch: "python"
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
   entry_points:
     - pybert = pybert.cli:cli
@@ -24,22 +24,22 @@ requirements:
     - swig
   host:
     - kiwisolver
-    - numpy x.x
+    - numpy {{ numpy }}
     - pyibis-ami >=4.1
     # - pyside6  # Not available in Anaconda, yet.
     - pyside2
-    - python
+    - python {{ python }}
     - pyyaml
     - qt >=5
     - scikit-rf >=0.24.1
     - setuptools
   run:
     - kiwisolver
-    - numpy x.x
+    - numpy {{ numpy }}
     - pyibis-ami >=4.1
     # - pyside6  # Not available in Anaconda, yet.
     - pyside2
-    - python
+    - python {{ python }}
     - pyyaml
     - qt >=5
     - scikit-rf >=0.24.1

--- a/conda.recipe/pyibis-ami/meta.yaml
+++ b/conda.recipe/pyibis-ami/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "pyibis-ami" %}
-{% set version = "4.1.0" %}
+{% set pyproject = load_file_data('../../PyAMI/pyproject.toml', from_recipe_dir=true, recipe_dir="conda.recipe/pyibis-ami") %}
+{% set version = pyproject.get('project', {}).get('version') %}
 
 package:
   version: '{{ version }}'
@@ -14,9 +15,7 @@ source:
   # git_depth: 1 # (Defaults to -1/not shallow)
 
 build:
-  # string: 4961a3_2
-  number: 1
-  # noarch: python
+  number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:
@@ -27,7 +26,7 @@ requirements:
     - git
     - swig
   host:
-    - chaco  >=5.1.0
+    - chaco  >=5.1.1
     - click >=8.1.3
     - Cython
     - empy >=3.3.4
@@ -40,7 +39,7 @@ requirements:
     - setuptools
 
   run:
-    - chaco  >=5.1.0
+    - chaco  >=5.1.1
     - click >=8.1.3
     - empy >=3.3.4
     - matplotlib >=3.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "PipBERT"
 description = "Serial communication link bit error rate tester simulator, written in Python."
-version = "4.1.0"
+version = "4.1.1"
 authors = [ {name = "David Banas",     email = "capn.freako@gmail.com"}
           , {name = "David Patterson"}
           ]
@@ -17,7 +17,7 @@ dependencies = [
         "PyIBIS-AMI>=4.1",
         "pyside2",
         "pyyaml>=6",
-        "scikit-rf>=0.24",
+        "scikit-rf>=0.24.1",
 ]
 keywords=["bert", "communication", "simulator"]
 classifiers=[

--- a/src/pybert/__init__.py
+++ b/src/pybert/__init__.py
@@ -13,7 +13,7 @@ Copyright (c) 2014 by David Banas; All rights reserved World wide.
 from importlib.metadata import version as _get_version
 
 # Set PEP396 version attribute
-__version__ = _get_version('PipBERT')  # PyPi "PyBERT" package name got stollen. :(
+__version__ = _get_version("PipBERT")  # PyPi "PyBERT" package name got stollen. :(
 __date__ = "April 6, 2023"
 __authors__ = "David Banas & David Patterson"
 __copy__ = "Copyright (c) 2014 David Banas, 2019 David Patterson"

--- a/src/pybert/__init__.py
+++ b/src/pybert/__init__.py
@@ -10,8 +10,11 @@ Testing by:      Mark Marlett <mark.marlett@gmail.com>
 
 Copyright (c) 2014 by David Banas; All rights reserved World wide.
 """
-__version__ = "4.1.0"
-__date__ = "March 15, 2023"
+from importlib.metadata import version as _get_version
+
+# Set PEP396 version attribute
+__version__ = _get_version('PipBERT')  # PyPi "PyBERT" package name got stollen. :(
+__date__ = "April 6, 2023"
 __authors__ = "David Banas & David Patterson"
 __copy__ = "Copyright (c) 2014 David Banas, 2019 David Patterson"
 


### PR DESCRIPTION
This resolves Issue #122 .

`pyproject.toml` is now the only file containing a hard-coded package version number.
Both the `conda-build` flow and the application now refer to `pyproject.toml` for versioning.
