### PR TITLE
141 update chacoenable to 600 for next release

### DIFF
--- a/conda.recipe/chaco/meta.yaml
+++ b/conda.recipe/chaco/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "chaco" %}
-{% set version = "5.1.1" %}
-{% set enable_version = "5.3.1" %}
+{% set version = "6.0.0" %}
+{% set enable_version = "6.0.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -11,10 +11,10 @@ source:
   git_rev: {{ version }}
 
 build:
-  number: 3
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
-  script_env:
-    - ETS_QT4_IMPORTS=1
+  # script_env:
+  #   - ETS_QT4_IMPORTS=1
 
 requirements:
   build:
@@ -31,21 +31,23 @@ requirements:
     - {{ cdt('libxxf86vm') }}            # [linux]
     - {{ cdt('libxext') }}               # [linux]
     - cmake
+    - Cython <3
     - git
+    - pip <23
+    - python {{ python }}
     - swig
   host:
-    - Cython
+    - Cython <3
     - enable ={{ enable_version }}
     - importlib_resources
     - numpy {{ numpy }}
-    - pyface >=7.4.2
+    - pip <23
     - python {{ python }}
     - setuptools
   run:
     - enable ={{ enable_version }}
     - importlib_resources
     - {{ pin_compatible('numpy') }}
-    - pyface >=7.4.2
     - python
 
 test:

--- a/conda.recipe/enable/meta.yaml
+++ b/conda.recipe/enable/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "enable" %}
-{% set version = "5.3.1" %}
+{% set version = "6.0.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -10,10 +10,10 @@ source:
   git_rev: {{version}}
 
 build:
-  number: 5
+  number: 1
   script: " {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
   script_env:
-    - CFLAGS=-Wno-c++11-narrowing
+    - CFLAGS=-Wno-c++11-narrowing -Wno-register -Wno-incompatible-function-pointer-types
 
 requirements:
   build:
@@ -30,32 +30,33 @@ requirements:
     - {{ cdt('libxxf86vm') }}            # [linux]
     - {{ cdt('libxext') }}               # [linux]
     - cmake
+    - Cython <3
     - git
+    - pip <23
+    - python {{ python }}
     - swig
   host:
-    - Cython  # Caused error when in `build:`.
+    - Cython <3
     - fonttools
     - numpy {{ numpy }}
-    - pillow >=9.4
-    - pip
-    - pyface >=7.4.2
+    - pillow >=10.1
+    - pip <23
+    - pyface >=8
     - pyparsing
+    - pyside6 >=6.6.1
     - python {{ python }}
-    - qt >=5
     - setuptools
-    - six
-    - traitsui
+    - traitsui >=8
     - xorg-libxfixes                     # [linux]
   run:
     - fonttools
     - {{ pin_compatible('numpy') }}
-    - pillow >=9.4
-    - pyface >=7.4.2
+    - pillow >=10.1
+    - pyface >=8
     - pyparsing
+    - pyside6 >=6.6.1
     - python
-    - qt >=5
-    - six
-    - traitsui
+    - traitsui >=8
 
 test:
   imports:
@@ -65,7 +66,7 @@ test:
     - enable.layout
     - enable.null
     - enable.primitives
-    - enable.qt4
+    - enable.qt
     - enable.savage
     - enable.savage.compliance
     - enable.savage.svg
@@ -78,11 +79,11 @@ test:
     - enable.savage.svg.tests.css
     - enable.savage.trait_defs
     - enable.savage.trait_defs.ui
-    - enable.savage.trait_defs.ui.qt4
+    - enable.savage.trait_defs.ui.qt
     - enable.savage.trait_defs.ui.wx
     - enable.tests
     - enable.tests.primitives
-    - enable.tests.qt4
+    - enable.tests.qt
     - enable.tests.tools
     - enable.tests.wx
     - enable.tools
@@ -91,7 +92,7 @@ test:
     - enable.tools.toolbars
     - enable.trait_defs
     - enable.trait_defs.ui
-    - enable.trait_defs.ui.qt4
+    - enable.trait_defs.ui.qt
     - enable.trait_defs.ui.wx
     - enable.wx
     - kiva

--- a/conda.recipe/parsec/meta.yaml
+++ b/conda.recipe/parsec/meta.yaml
@@ -9,17 +9,17 @@ source:
   path: ../../parsec.py
 
 build:
-  number: 1
+  number: 2
   noarch: "python"
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:
   build:
-    - python >=3.6,<3.10
+    - python >=3.6,<3.12
     - setuptools
 
   run:
-    - python >=3.6,<3.10
+    - python >=3.6,<3.12
 
 test:
   # Python imports

--- a/conda.recipe/pybert/meta.yaml
+++ b/conda.recipe/pybert/meta.yaml
@@ -11,7 +11,7 @@ source:
   path: ../../
 
 build:
-  number: 3
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
   entry_points:
     - pybert = pybert.cli:cli

--- a/conda.recipe/pybert/meta.yaml
+++ b/conda.recipe/pybert/meta.yaml
@@ -22,9 +22,12 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - git
+    - pip <23
+    - python {{ python }}
     - swig
   host:
     - numpy {{ numpy }}
+    - pip <23
     - python {{ python }}
     - setuptools
     {% for dep in deps %}
@@ -39,7 +42,23 @@ requirements:
 
 test:
   imports:
-    - pybert
+    - pybert.cli
+    - pybert.configuration
+    - pybert.pybert
+    - pybert.results
+    - pybert.utility
+    - pybert.gui.handler
+    - pybert.gui.help
+    - pybert.gui.plot
+    - pybert.gui.view
+    - pybert.models.bert
+    - pybert.models.cdr
+    - pybert.models.dfe
+    - pybert.models.tx_tap
+    - pybert.parsers.hspice
+    - pybert.threads.optimization
+    - pybert.threads.sim
+    - pybert.threads.stoppable
 
 about:
   dev_url: ''

--- a/conda.recipe/pyibis-ami/meta.yaml
+++ b/conda.recipe/pyibis-ami/meta.yaml
@@ -25,14 +25,18 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
+    - Cython <3
     - git
+    - pip <23
+    - python {{ python }}
     - swig
     {% for req in build_reqs %}
     - {{ req }}
     {% endfor %}
   host:
-    - Cython
+    - Cython <3
     - numpy {{ numpy }}
+    - pip <23
     - python {{ python }}
     - setuptools
     {% for dep in deps %}

--- a/conda.recipe/pyibis-ami/meta.yaml
+++ b/conda.recipe/pyibis-ami/meta.yaml
@@ -17,7 +17,7 @@ source:
   # git_depth: 1 # (Defaults to -1/not shallow)
 
 build:
-  number: 1
+  number: 2
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:

--- a/conda.recipe/pyibis-ami/meta.yaml
+++ b/conda.recipe/pyibis-ami/meta.yaml
@@ -17,7 +17,7 @@ source:
   # git_depth: 1 # (Defaults to -1/not shallow)
 
 build:
-  number: 2
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -11,6 +11,8 @@ numpy:
 python:
   - 3.9
 channels:
+  - local
   - dbanas
-  - defaults
   - conda-forge
+  - defaults
+  - labscript-suite

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -7,9 +7,9 @@ cxx_compiler:
   - clangxx                    # [osx]
   - vs2019                     # [win]
 numpy:
-  - 1.23
+  - 1.25  # 1.26 breaks the Chaco build.
 python:
-  - 3.9
+  - 3.11
 channels:
   - local
   - dbanas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,20 +5,20 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "PipBERT"
 description = "Serial communication link bit error rate tester simulator, written in Python."
-version = "4.2.1rc1"
+version = "5.1.0rc1"
 authors = [ {name = "David Banas",     email = "capn.freako@gmail.com"}
           , {name = "David Patterson"}
           ]
 urls = { documentation = "https://github.com/capn-freako/PyBERT/wiki"}
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.12"
 license = {text = "BSD"}
 dependencies = [
         "kiwisolver",
-        "PyIBIS-AMI>=4.2.1rc1",
-        "pyside2",
+        "PyIBIS-AMI>=5.1.0rc1",
+        # "pyside2",
         "pyyaml>=6",
-        "qt>=5",
+        # "qt>=5",
         "scikit-rf>=0.29",
 ]
 keywords=["bert", "communication", "simulator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,21 +5,21 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "PipBERT"
 description = "Serial communication link bit error rate tester simulator, written in Python."
-version = "4.1.2"
+version = "4.2.1rc1"
 authors = [ {name = "David Banas",     email = "capn.freako@gmail.com"}
           , {name = "David Patterson"}
           ]
 urls = { documentation = "https://github.com/capn-freako/PyBERT/wiki"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "BSD"}
 dependencies = [
         "kiwisolver",
-        "PyIBIS-AMI>=4.1.2",
+        "PyIBIS-AMI>=4.2.1rc1",
         "pyside2",
         "pyyaml>=6",
         "qt>=5",
-        "scikit-rf>=0.24.1",
+        "scikit-rf>=0.29",
 ]
 keywords=["bert", "communication", "simulator"]
 classifiers=[

--- a/src/pybert/__init__.py
+++ b/src/pybert/__init__.py
@@ -27,8 +27,8 @@ __copy__ = "Copyright (c) 2014 David Banas, 2019 David Patterson"
 # You should only have one of the "ETSConfig.toolkit = ..." lines uncommented.
 # fmt: off
 # isort: off
-from traits.etsconfig.api import ETSConfig
-ETSConfig.toolkit = 'qt4'  # Yields unacceptably small font sizes in plot axis labels.
+# from traits.etsconfig.api import ETSConfig
+# ETSConfig.toolkit = 'qt4'  # Yields unacceptably small font sizes in plot axis labels.
 # ETSConfig.toolkit = 'qt4.celiagg'   # Yields unacceptably small font sizes in plot axis labels.
 # ETSConfig.toolkit = 'qt.qpainter'  # Was causing crash on Mac.
 # ETSConfig.toolkit = 'qt.image'     # Program runs, but very small fonts in plot titles and axis labels.

--- a/tests/test_sim_thread.py
+++ b/tests/test_sim_thread.py
@@ -15,6 +15,6 @@ def test_simulation_can_abort():
     sim.the_pybert = app
     sim.start()  # Start the thread
     sim.stop()  # Abort the thread
-    sim.join(10)  # Join and wait until it ends or 10 seconds passed.
+    sim.join(60)  # Join and wait until it ends or 10 seconds passed.
 
     assert "Aborted" in app.status_str


### PR DESCRIPTION
Both _Enable_ and _Chaco_ 6.0.0 are building successfully for:

- _NumPy_ 1.25, and
- _Python_ 3.9, 10, and 11.

(_NumPy_ 1.26 breaks the Chaco build.)
