### PR TITLE
Add Native/IBIS Selectors for IBIS-AMI and Minor UI Changes

### DIFF
--- a/src/pybert/configuration.py
+++ b/src/pybert/configuration.py
@@ -112,12 +112,14 @@ class PyBertCfg:  # pylint: disable=too-many-instance-attributes
         self.tx_dll_file = the_PyBERT.tx_dll_file
         self.tx_ibis_file = the_PyBERT.tx_ibis_file
         self.tx_sel = the_PyBERT.tx_sel
+        self.tx_eq_sel = the_PyBERT.tx_eq_sel
 
         # Rx
         self.rin = the_PyBERT.rin
         self.cin = the_PyBERT.cin
         self.cac = the_PyBERT.cac
         self.use_ctle_file = the_PyBERT.use_ctle_file
+        self.ctle_sel = the_PyBERT.ctle_sel
         self.ctle_file = the_PyBERT.ctle_file
         self.rx_bw = the_PyBERT.rx_bw
         self.peak_freq = the_PyBERT.peak_freq
@@ -130,6 +132,7 @@ class PyBertCfg:  # pylint: disable=too-many-instance-attributes
         self.rx_dll_file = the_PyBERT.rx_dll_file
         self.rx_ibis_file = the_PyBERT.rx_ibis_file
         self.rx_sel = the_PyBERT.rx_sel
+        self.rx_eq_sel = the_PyBERT.rx_eq_sel
         self.rx_use_viterbi = the_PyBERT.rx_use_viterbi
         self.rx_viterbi_symbols = the_PyBERT.rx_viterbi_symbols
         self.rx_n_taps = the_PyBERT.rx_n_taps
@@ -221,6 +224,12 @@ class PyBertCfg:  # pylint: disable=too-many-instance-attributes
                     setattr(pybert.dfe_tap_tuners[count], "enabled", enabled)
                     setattr(pybert.dfe_tap_tuners[count], "min_val", min_val)
                     setattr(pybert.dfe_tap_tuners[count], "max_val", max_val)
+            elif prop in ("tx_eq_sel", "rx_eq_sel"):
+                lower_map = {"native": "Native", "ibis-ami": "IBIS-AMI"}
+                setattr(pybert, prop, lower_map.get(str(value).lower(), value))
+            elif prop == "ctle_sel":
+                lower_map = {"native": "Native", "file": "File"}
+                setattr(pybert, prop, lower_map.get(str(value).lower(), value))
             elif prop in ("version", "date_created"):
                 pass  # Just including it for some good housekeeping.  Not currently used.
             elif prop == "use_ch_file":

--- a/src/pybert/gui/view.py
+++ b/src/pybert/gui/view.py
@@ -159,22 +159,15 @@ traits_view = View(
                             show_border=True,
                         ),
                         VGroup(
-                            HGroup(
-                                Item(name="vod", label="Vod", tooltip="Tx output voltage into matched load"),
-                                Item(label="V"),
-                            ),
-                            HGroup(
-                                Item(name="rn", label="Rn", tooltip="standard deviation of random noise"),
-                                Item(label="V"),
-                            ),
-                            HGroup(
-                                Item(name="pn_mag", label="Pn", tooltip="peak magnitude of periodic noise"),
-                                Item(label="V"),
-                            ),
-                            HGroup(
-                                Item(name="pn_freq", label="f(Pn)", tooltip="frequency of periodic noise"),
-                                Item(label="MHz"),
-                            ),
+                            Item(name="vod", label="Vod", tooltip="Tx output voltage into matched load"),
+                            Item(label="V"),
+                            Item(name="rn", label="Rn", tooltip="standard deviation of random noise"),
+                            Item(label="V"),
+                            Item(name="pn_mag", label="Pn", tooltip="peak magnitude of periodic noise"),
+                            Item(label="V"),
+                            Item(name="pn_freq", label="f(Pn)", tooltip="frequency of periodic noise"),
+                            Item(label="MHz"),
+                            columns=2,
                             label="Tx Level && Noise",
                             show_border=True,
                         ),
@@ -200,42 +193,31 @@ traits_view = View(
                     show_border=True,
                 ),
                 VGroup(
-                    HGroup(
-                        Item(
-                            name="impulse_length",
-                            label="Impulse Response Length",
-                            tooltip="Manual impulse response length override",
-                        ),
-                        Item(label="ns"),
-                        spring,
+                    Item(
+                        name="impulse_length",
+                        label="Impulse Response Length",
+                        tooltip="Manual impulse response length override",
                     ),
-                    HGroup(
-                        Item(
-                            name="thresh",
-                            label="Pj Threshold",
-                            tooltip="Threshold for identifying periodic jitter spectral elements. (sigma)",
-                        ),
-                        Item(label="sigma"),
-                        spring,
+                    Item(label="ns"),
+                    Item(
+                        name="thresh",
+                        label="Pj Threshold",
+                        tooltip="Threshold for identifying periodic jitter spectral elements. (sigma)",
                     ),
-                    HGroup(
-                        Item(
-                            name="f_max",
-                            label="fMax",
-                            tooltip="Maximum frequency used for plotting, modeling, and signal processing. (GHz)",
-                        ),
-                        Item(label="GHz"),
-                        spring,
+                    Item(label="sigma"),
+                    Item(
+                        name="f_max",
+                        label="fMax",
+                        tooltip="Maximum frequency used for plotting, modeling, and signal processing. (GHz)",
                     ),
-                    HGroup(
-                        Item(
-                            name="f_step",
-                            label="fStep",
-                            tooltip="Frequency step used for plotting, modeling, and signal processing. (MHz)",
-                        ),
-                        Item(label="MHz"),
-                        spring,
+                    Item(label="GHz"),
+                    Item(
+                        name="f_step",
+                        label="fStep",
+                        tooltip="Frequency step used for plotting, modeling, and signal processing. (MHz)",
                     ),
+                    Item(label="MHz"),
+                    columns=2,
                     label="Analysis Parameters",
                     show_border=True,
                 ),
@@ -244,28 +226,21 @@ traits_view = View(
                 VGroup(  # "Tx"
                     Item("tx_sel", style="custom"),
                     VGroup(
-                        HGroup(
-                            Item(
-                                name="rs",
-                                label="Tx_Rs",
-                                tooltip="Tx differential source impedance",
-                            ),
-                            Item(label="Ohms"),
-                            spring,
+                        Item(
+                            name="rs",
+                            label="Tx_Rs",
+                            tooltip="Tx differential source impedance",
                         ),
-                        HGroup(
-                            Item(
-                                name="cout",
-                                label="Tx_Cout",
-                                tooltip="Tx parasitic output capacitance (each pin)",
-                                editor=TextEditor(auto_set=False, enter_set=True, evaluate=float),
-                            ),
-                            Item(label="pF"),
-                            spring,
+                        Item(label="Ohms"),
+                        Item(
+                            name="cout",
+                            label="Tx_Cout",
+                            tooltip="Tx parasitic output capacitance (each pin)",
+                            editor=TextEditor(auto_set=False, enter_set=True, evaluate=float),
                         ),
-                        label="Native",
+                        Item(label="pF"),
+                        columns=2,
                         visible_when="tx_sel == 'native'",
-                        show_border=True,
                     ),
                     VGroup(
                         HGroup(
@@ -289,10 +264,10 @@ traits_view = View(
                         Item(name="tx_use_ts4", label="Use on-die S-parameters.",
                              enabled_when="tx_ibis_valid and tx_has_ts4",
                         ),
-                        label="IBIS",
+                        # label="IBIS",
                         visible_when="tx_sel == 'ibis'",
-                        show_border=True,
                     ),
+                    spring,
                     label="Tx",
                     show_border=True,
                 ),
@@ -313,70 +288,23 @@ traits_view = View(
                             enabled_when="inter_sel != 'native'",
                         ),
                     ),
-                    HGroup(  # Native (i.e. - Howard Johnson's) interconnect model.
-                        VGroup(
-                            HGroup(
-                                Item(
-                                    name="l_ch",
-                                    label="Length",
-                                    tooltip="interconnect length",
-                                ),
-                                Item(label="m"),
-                            ),
-                            HGroup(
-                                Item(
-                                    name="Theta0",
-                                    label="Loss Tan.",
-                                    tooltip="dielectric loss tangent",
-                                ),
-                            ),
-                        ),
-                        VGroup(
-                            HGroup(
-                                Item(
-                                    name="Z0",
-                                    label="Z0",
-                                    tooltip="characteristic differential impedance",
-                                ),
-                                Item(label="Ohms"),
-                            ),
-                            HGroup(
-                                Item(
-                                    name="v0",
-                                    label="v_rel",
-                                    tooltip="normalized propagation velocity",
-                                ),
-                                Item(label="c"),
-                            ),
-                        ),
-                        VGroup(
-                            HGroup(
-                                Item(
-                                    name="Rdc",
-                                    label="Rdc",
-                                    tooltip="d.c. resistance",
-                                ),
-                                Item(label="Ohms"),
-                            ),
-                            HGroup(
-                                Item(
-                                    name="w0",
-                                    label="w0",
-                                    tooltip="transition frequency",
-                                ),
-                                Item(label="rads./s"),
-                            ),
-                        ),
-                        VGroup(
-                            HGroup(
-                                Item(
-                                    name="R0",
-                                    label="R0",
-                                    tooltip="skin effect resistance",
-                                ),
-                                Item(label="Ohms"),
-                            ),
-                        ),
+                    VGroup(  # Native (i.e. - Howard Johnson's) interconnect model.
+                        Item(name="l_ch", label="Length", tooltip="interconnect length"),
+                        Item(label="m"),
+                        Item(name="Theta0", label="Loss Tan.", tooltip="dielectric loss tangent"),
+                        Item(label=""),
+                        Item(name="Z0", label="Z0", tooltip="characteristic differential impedance"),
+                        Item(label="Ohms"),
+                        Item(name="v0", label="v_rel", tooltip="normalized propagation velocity"),
+                        Item(label="c"),
+                        Item(name="Rdc", label="Rdc", tooltip="d.c. resistance"),
+                        Item(label="Ohms"),
+                        Item(name="w0", label="w0", tooltip="transition frequency"),
+                        Item(label="rads./s"),
+                        Item(name="R0", label="R0", tooltip="skin effect resistance"),
+                        Item(label="Ohms"),
+                        spring,
+                        columns=2,
                         label="Native",
                         visible_when="inter_sel == 'native'",
                         show_border=True,
@@ -434,6 +362,7 @@ traits_view = View(
                             name="ch_files",
                             style="custom",
                             show_label=False,
+                            springy=True,
                             editor=ListEditor(
                                 editor=FileEditor(
                                     dialog_style="open",
@@ -448,6 +377,7 @@ traits_view = View(
                         visible_when="inter_sel == 'multiple'",
                         show_border=True,
                     ),
+                    spring,
                     label="Interconnect",
                     show_border=True,
                 ),
@@ -493,9 +423,8 @@ traits_view = View(
                                 tooltip="Number of symbols to include in MLSD trellis.",
                             ),
                         ),
-                        label="Native",
+                        # label="Native",
                         visible_when="rx_sel == 'native'",
-                        show_border=True,
                     ),
                     VGroup(
                         HGroup(
@@ -519,15 +448,16 @@ traits_view = View(
                         Item(name="rx_use_ts4", label="Use on-die S-parameters.",
                              enabled_when="rx_ibis_valid and rx_has_ts4",
                         ),
-                        label="IBIS",
+                        # label="IBIS",
                         visible_when="rx_sel == 'ibis'",
-                        show_border=True,
                     ),
+                    spring,
                     label="Rx",
                     show_border=True,
                 ),
                 label="Channel",
                 show_border=True,
+                springy=True,
             ),
             label="Config.",
             id="config",
@@ -824,31 +754,22 @@ traits_view = View(
                 VGroup(  # Rx CTLE
                     Item(name="ctle_enable_tune", label="Enable", tooltip="CTLE enable",),
                     VGroup(
-                        HGroup(
-                            Item(name="peak_freq_tune", label="fp", tooltip="CTLE peaking frequency (GHz)",
-                                 enabled_when="ctle_enable_tune",),
-                            Item(label="GHz"),
-                        ),
-                        HGroup(
-                            Item(name="rx_bw_tune", label="BW", tooltip="unequalized signal path bandwidth (GHz).",
-                                 enabled_when="ctle_enable_tune",),
-                            Item(label="GHz"),
-                        ),
-                        HGroup(
-                            Item(name="min_mag_tune", label="Min.", tooltip="CTLE peaking magnitude minimum (dB)",
-                                 format_str="%4.1f", enabled_when="ctle_enable_tune",),
-                            Item(label="dB"),
-                        ),
-                        HGroup(
-                            Item(name="max_mag_tune", label="Max.", tooltip="CTLE peaking magnitude maximum (dB)",
-                                 format_str="%4.1f", enabled_when="ctle_enable_tune",),
-                            Item(label="dB"),
-                        ),
-                        HGroup(
-                            Item(name="step_mag_tune", label="Step", tooltip="CTLE peaking magnitude step (dB)",
-                                 format_str="%4.1f", enabled_when="ctle_enable_tune",),
-                            Item(label="dB"),
-                        ),
+                        Item(name="peak_freq_tune", label="fp", tooltip="CTLE peaking frequency (GHz)",
+                             enabled_when="ctle_enable_tune",),
+                        Item(label="GHz"),
+                        Item(name="rx_bw_tune", label="BW", tooltip="unequalized signal path bandwidth (GHz).",
+                             enabled_when="ctle_enable_tune",),
+                        Item(label="GHz"),
+                        Item(name="min_mag_tune", label="Min.", tooltip="CTLE peaking magnitude minimum (dB)",
+                             format_str="%4.1f", enabled_when="ctle_enable_tune",),
+                        Item(label="dB"),
+                        Item(name="max_mag_tune", label="Max.", tooltip="CTLE peaking magnitude maximum (dB)",
+                             format_str="%4.1f", enabled_when="ctle_enable_tune",),
+                        Item(label="dB"),
+                        Item(name="step_mag_tune", label="Step", tooltip="CTLE peaking magnitude step (dB)",
+                             format_str="%4.1f", enabled_when="ctle_enable_tune",),
+                        Item(label="dB"),
+                        columns=2,
                         label="Configuration",
                         show_border=True,
                         enabled_when="ctle_enable_tune",

--- a/src/pybert/gui/view.py
+++ b/src/pybert/gui/view.py
@@ -465,6 +465,7 @@ traits_view = View(
         # "Equalization" tab.
         HGroup(  # Channel Parameters
             VGroup(  # Tx EQ
+                Item("tx_eq_sel", style="custom"),
                 VGroup(
                     HGroup(
                         VGroup(
@@ -481,16 +482,10 @@ traits_view = View(
                         ),
                         VGroup(
                             Item(
-                                name="tx_use_ami",
-                                label="Use AMI",
-                                tooltip="You must select both files, first.",
-                                enabled_when="tx_ami_valid == True and tx_dll_valid == True",
-                            ),
-                            Item(
                                 name="tx_use_getwave",
                                 label="Use GetWave",
                                 tooltip="Use the model's GetWave() function.",
-                                enabled_when="tx_use_ami and tx_has_getwave",
+                                enabled_when="tx_has_getwave",
                             ),
                             Item(
                                 "btn_cfg_tx",
@@ -501,11 +496,12 @@ traits_view = View(
                         ),
                     ),
                     label="IBIS-AMI",
-                    show_border=True,
+                    visible_when="tx_eq_sel == 'IBIS-AMI'",
                 ),
                 VGroup(
                     Item(
                         name="tx_taps",
+                        springy=True,
                         editor=TableEditor(
                             columns=[
                                 ObjectColumn(name="name", editable=False),
@@ -521,13 +517,15 @@ traits_view = View(
                         show_label=False,
                     ),
                     label="Native",
-                    show_border=True,
-                    enabled_when="tx_use_ami == False",
+                    springy=True,
+                    visible_when="tx_eq_sel == 'Native'",
                 ),
                 label="Tx Equalization",
                 show_border=True,
+                springy=True,
             ),
             VGroup(  # Rx EQ
+                Item("rx_eq_sel", style="custom"),
                 VGroup(
                     HGroup(
                         VGroup(
@@ -544,16 +542,10 @@ traits_view = View(
                         ),
                         VGroup(
                             Item(
-                                name="rx_use_ami",
-                                label="Use AMI",
-                                tooltip="You must select both files, first.",
-                                enabled_when="rx_ami_valid == True and rx_dll_valid == True",
-                            ),
-                            Item(
                                 name="rx_use_getwave",
                                 label="Use GetWave",
                                 tooltip="Use the model's GetWave() function.",
-                                enabled_when="rx_use_ami and rx_has_getwave",
+                                enabled_when="rx_has_getwave",
                             ),
                             Item(
                                 name="rx_use_clocks",
@@ -570,63 +562,34 @@ traits_view = View(
                         ),
                     ),
                     label="IBIS-AMI",
-                    show_border=True,
+                    visible_when="rx_eq_sel == 'IBIS-AMI'",
                 ),
                 VGroup(
                     HGroup(
                         VGroup(  # CTLE
-                            Item(name="ctle_enable", label="Enable", tooltip="CTLE enable",),
+                            Item(name="ctle_enable", label="Enable", tooltip="CTLE enable"),
+                            Item("ctle_sel", style="custom", enabled_when="ctle_enable"),
                             HGroup(  # File
-                                Item(
-                                    name="use_ctle_file",
-                                    label="Use",
-                                    tooltip="Select CTLE impulse/step response from file.",
-                                    enabled_when="ctle_file",
-                                ),
                                 Item(
                                     name="ctle_file",
                                     label="Filename",
+                                    springy=True,
                                     editor=FileEditor(dialog_style="open", filter=["*.csv"]),
                                 ),
-                                label="File",
-                                show_border=True,
+                                visible_when="ctle_sel == 'File'",
                             ),
-                            VGroup(  # Model
-                                HGroup(
-                                    Item(
-                                        name="peak_freq",
-                                        label="CTLE fp",
-                                        tooltip="CTLE peaking frequency (GHz)",
-                                        enabled_when="use_ctle_file == False",
-                                    ),
-                                    Item(label="GHz"),
-                                    spring,
-                                    Item(
-                                        name="rx_bw",
-                                        label="Bandwidth",
-                                        tooltip="unequalized signal path bandwidth (GHz).",
-                                        enabled_when="use_ctle_file == False",
-                                    ),
-                                    Item(label="GHz"),
-                                ),
-                                HGroup(
-                                    Item(
-                                        name="peak_mag",
-                                        label="CTLE boost",
-                                        tooltip="CTLE peaking magnitude (dB)",
-                                        format_str="%4.1f",
-                                        enabled_when="use_ctle_file == False",
-                                    ),
-                                    Item(label="dB"),
-                                    spring,
-                                ),
-                                label="Model",
-                                show_border=True,
-                                enabled_when="use_ctle_file == False",
+                            VGroup(  # Native model
+                                Item(name="peak_freq", label="CTLE fp", tooltip="CTLE peaking frequency (GHz)"),
+                                Item(label="GHz"),
+                                Item(name="rx_bw", label="Bandwidth", tooltip="unequalized signal path bandwidth (GHz)."),
+                                Item(label="GHz"),
+                                Item(name="peak_mag", label="CTLE boost", tooltip="CTLE peaking magnitude (dB)", format_str="%4.1f"),
+                                Item(label="dB"),
+                                columns=2,
+                                visible_when="ctle_sel == 'Native'",
                             ),
                             label="CTLE",
                             show_border=True,
-                            enabled_when="rx_use_ami == False",
                         ),
                         VGroup(  # CDR
                             HGroup(
@@ -713,11 +676,11 @@ traits_view = View(
                         ),
                     ),
                     label="Native",
-                    show_border=True,
-                    enabled_when="rx_use_ami == False",
+                    visible_when="rx_eq_sel == 'Native'",
                 ),
                 label="Rx Equalization",
                 show_border=True,
+                springy=True,
             ),
             label="Equalization",
             id="equalization",

--- a/src/pybert/models/bert.py
+++ b/src/pybert/models/bert.py
@@ -111,6 +111,28 @@ def my_run_simulation(self, initial_run: bool = False, update_plots: bool = True
             self.status = "Aborted Simulation"
             raise RuntimeError("Simulation aborted by User.")
 
+    # Preflight checks.
+    if self.tx_sel == "ibis" and not self.tx_ibis_valid:
+        msg = "ERROR: Tx set to IBIS but no valid IBIS file loaded."
+        self.log(msg)
+        self.status = msg
+        return
+    if self.tx_eq_sel == "IBIS-AMI" and not (self.tx_ibis_valid and self.tx_ami_valid and self.tx_dll_valid):
+        msg = "ERROR: Tx equalization set to IBIS-AMI but IBIS/AMI/DLL files are not all valid."
+        self.log(msg)
+        self.status = msg
+        return
+    if self.rx_sel == "ibis" and not self.rx_ibis_valid:
+        msg = "ERROR: Rx set to IBIS but no valid IBIS file loaded."
+        self.log(msg)
+        self.status = msg
+        return
+    if self.rx_eq_sel == "IBIS-AMI" and not (self.rx_ibis_valid and self.rx_ami_valid and self.rx_dll_valid):
+        msg = "ERROR: Rx equalization set to IBIS-AMI but IBIS/AMI/DLL files are not all valid."
+        self.log(msg)
+        self.status = msg
+        return
+
     start_time = clock()
     self.status = "Running channel..."
 

--- a/src/pybert/pybert.py
+++ b/src/pybert/pybert.py
@@ -219,6 +219,7 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
 
     # - Tx
     tx_sel = Enum("native", "ibis")
+    tx_eq_sel = Enum("Native", "IBIS-AMI")
     # -- native
     vod = Float(1.0)  #: Tx differential output voltage (V)
     rs = Float(100)  #: Tx source impedance (Ohms)
@@ -252,11 +253,13 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
 
     # - Rx
     rx_sel = Enum("native", "ibis")
+    rx_eq_sel = Enum("Native", "IBIS-AMI")
     # -- native
     rin = Float(100)  #: Rx input impedance (Ohm)
     cin = Float(0.5)  #: Rx parasitic input capacitance (pF)
     cac = Float(1.0)  #: Rx a.c. coupling capacitance (uF)
     use_ctle_file = Bool(False)  #: For importing CTLE impulse/step response directly.
+    ctle_sel = Enum("Native", "File")
     ctle_file = File("")  #: CTLE response file (when use_ctle_file = True).
     rx_bw = Float(12.0)  #: CTLE bandwidth (GHz).
     peak_freq = Float(gPeakFreq)  #: CTLE peaking frequency (GHz)
@@ -1109,12 +1112,23 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
         self.rx_taps = rx_taps
         self.ffe_tap_tuners = ffe_tap_tuners
 
+    def _tx_sel_changed(self, new):
+        if new != "ibis":
+            self.tx_eq_sel = "Native"
+
+    def _tx_eq_sel_changed(self, new):
+        if new == "IBIS-AMI" and not (self.tx_sel == "ibis" and self.tx_ami_valid and self.tx_dll_valid):
+            self.log("Tx equalization: select an IBIS model with AMI configuration before switching to IBIS-AMI mode.")
+            return
+        self.tx_use_ami = new == "IBIS-AMI"
+
     def _tx_ibis_file_changed(self, new_value):
         self.status = f"Parsing IBIS file: {new_value}"
         dName = ""
         try:
             self.tx_ibis_valid = False
             self.tx_use_ami = False
+            self.tx_eq_sel = "Native"
             self.log(f"Parsing Tx IBIS file, '{new_value}'...")
             ibis = IBISModel(new_value, debug=self.debug, gui=self.GUI)
             self.log(f"  Result:\n{ibis.ibis_parsing_errors}")
@@ -1171,12 +1185,26 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
             error_message = f"Failed to open DLL/SO file!\n{err}"
             self.log(error_message, alert=True)
 
+    def _ctle_sel_changed(self, new):
+        self.use_ctle_file = new == "File"
+
+    def _rx_sel_changed(self, new):
+        if new != "ibis":
+            self.rx_eq_sel = "Native"
+
+    def _rx_eq_sel_changed(self, new):
+        if new == "IBIS-AMI" and not (self.rx_sel == "ibis" and self.rx_ami_valid and self.rx_dll_valid):
+            self.log("Rx equalization: select an IBIS model with AMI configuration before switching to IBIS-AMI mode.")
+            return
+        self.rx_use_ami = new == "IBIS-AMI"
+
     def _rx_ibis_file_changed(self, new_value):
         self.status = f"Parsing IBIS file: {new_value}"
         dName = ""
         try:
             self.rx_ibis_valid = False
             self.rx_use_ami = False
+            self.rx_eq_sel = "Native"
             self.log(f"Parsing Rx IBIS file, '{new_value}'...")
             ibis = IBISModel(new_value, debug=self.debug, gui=self.GUI)
             self.log(f"  Result:\n{ibis.ibis_parsing_errors}")

--- a/tests/test_loading_and_saving.py
+++ b/tests/test_loading_and_saving.py
@@ -147,6 +147,71 @@ def test_load_config_from_invalid(dut, tmp_path: Path):
 
 
 @pytest.mark.usefixtures("dut")
+def test_new_eq_selector_traits_round_trip(dut, tmp_path: Path):
+    """tx_eq_sel, rx_eq_sel, and ctle_sel survive a yaml save/load round-trip."""
+    # tx_eq_sel stays "Native" without valid AMI — set it via internal path to bypass guard.
+    dut.ctle_sel = "File"  # no guard on this one
+
+    save_file = tmp_path / "eq_sel.yaml"
+    dut.save_configuration(save_file)
+
+    dut2 = PyBERT(run_simulation=False, gui=False)
+    dut2.load_configuration(save_file)
+
+    assert dut2.tx_eq_sel == "Native",  f"tx_eq_sel: expected 'Native', got {dut2.tx_eq_sel!r}"
+    assert dut2.rx_eq_sel == "Native",  f"rx_eq_sel: expected 'Native', got {dut2.rx_eq_sel!r}"
+    assert dut2.ctle_sel  == "File",    f"ctle_sel:  expected 'File',   got {dut2.ctle_sel!r}"
+
+
+def test_ctle_sel_syncs_use_ctle_file():
+    """Setting ctle_sel drives use_ctle_file."""
+    dut = PyBERT(run_simulation=False, gui=False)
+    assert dut.use_ctle_file is False
+    dut.ctle_sel = "File"
+    assert dut.use_ctle_file is True, "use_ctle_file should be True when ctle_sel='File'"
+    dut.ctle_sel = "Native"
+    assert dut.use_ctle_file is False, "use_ctle_file should be False when ctle_sel='Native'"
+
+
+def test_eq_sel_case_insensitive_load(tmp_path: Path):
+    """tx_eq_sel, rx_eq_sel, ctle_sel load correctly when written in any case in the config file."""
+    dut = PyBERT(run_simulation=False, gui=False)
+    save_file = tmp_path / "case_test.yaml"
+    dut.save_configuration(save_file)
+
+    with open(save_file, "r", encoding="UTF-8") as f:
+        cfg = yaml.load(f, Loader=yaml.Loader)
+    cfg.tx_eq_sel = "native"     # lowercase
+    cfg.rx_eq_sel = "NATIVE"     # uppercase
+    cfg.ctle_sel  = "FILE"       # uppercase
+    with open(save_file, "w", encoding="UTF-8") as f:
+        yaml.dump(cfg, f)
+
+    dut2 = PyBERT(run_simulation=False, gui=False)
+    dut2.load_configuration(save_file)
+
+    assert dut2.tx_eq_sel == "Native", f"Expected 'Native', got {dut2.tx_eq_sel!r}"
+    assert dut2.rx_eq_sel == "Native", f"Expected 'Native', got {dut2.rx_eq_sel!r}"
+    assert dut2.ctle_sel  == "File",   f"Expected 'File',   got {dut2.ctle_sel!r}"
+
+
+def test_eq_sel_guard_no_ami():
+    """tx_eq_sel/rx_eq_sel log a warning and leave tx_use_ami/rx_use_ami False when AMI not configured."""
+    dut = PyBERT(run_simulation=False, gui=False)
+    assert dut.tx_ami_valid is False
+    assert dut.rx_ami_valid is False
+
+    dut.tx_eq_sel = "IBIS-AMI"
+    assert dut.tx_eq_sel  == "IBIS-AMI", "selector should accept the click (no snap-back)"
+    assert dut.tx_use_ami is False,       "tx_use_ami must not be armed when guard fires"
+    assert "IBIS-AMI mode" in dut.console_log, "guard should log a warning"
+
+    dut.rx_eq_sel = "IBIS-AMI"
+    assert dut.rx_eq_sel  == "IBIS-AMI", "selector should accept the click (no snap-back)"
+    assert dut.rx_use_ami is False,       "rx_use_ami must not be armed when guard fires"
+
+
+@pytest.mark.usefixtures("dut")
 def test_load_results_from_pickle(dut, tmp_path: Path):
     """Make sure that pybert can correctly load a pickle file."""
     save_file = tmp_path.joinpath("config.pybert_data")


### PR DESCRIPTION
Slowly catching up on changes in the last few PRs.  

- Apply the toggle to anything that used to have a "use this or that".  
    - TX/RX Equalization
    - CTLE File vs. Native
- Switch to a few Groups to use `column=2` to make them pad visually the same for the whole group.
- Add springy to a few Groups so they stretch to fill the available space.
- Add some guard rails for a IBIS selected but no valid vs. just raising an exception of a crypic message..  Shows up in log and status bar.