### PR TITLE
Replaced network renormalization w/ `calc_G()` in `calc_chnl_h()`.

### DIFF
--- a/src/pybert/models/bert.py
+++ b/src/pybert/models/bert.py
@@ -687,7 +687,13 @@ def my_run_simulation(self, initial_run: bool = False, update_plots: bool = True
             path = decoder.decode(list(sig_samps), dbg_dict=self.dbg_dict_viterbi)
             _states = decoder.states
             symbols_viterbi = list(map(lambda ix: _states[ix][-1], path))
-            bits_out_viterbi = sum(list(map(lambda ss: dfe.decide(ss)[1], symbols_viterbi)), [])
+            # `symbols_viterbi` values are on the Viterbi decoder's normalized
+            # (i.e. - unit amplitude) scale, while `dfe.decide()`'s thresholds
+            # are set relative to `dfe.decision_scaler` (the DFE's actual
+            # adapted slicer level). Rescale before slicing, so inner/outer
+            # PAM-4 levels are classified correctly.
+            bits_out_viterbi = sum(
+                list(map(lambda ss: dfe.decide(ss * dfe.decision_scaler)[1], symbols_viterbi)), [])
 
         n_errs_viterbi, bit_errs_viterbi = calc_ber(bits_out_viterbi)
 

--- a/src/pybert/pybert.py
+++ b/src/pybert/pybert.py
@@ -663,15 +663,6 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
         mod_type = self.mod_type_
         vod = self.vod
         bits = self.bits
-        Rs = self.rs
-        RL = self.rin
-
-        if self.tx_sel == "ibis":
-            model = self._tx_ibis.model
-            Rs = model.zout * 2
-        if self.rx_sel == "ibis":
-            model = self._rx_ibis.model
-            RL = model.zin * 2
 
         if mod_type == 0:  # NRZ
             symbols = 2 * bits - 1
@@ -702,11 +693,7 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
         else:
             raise ValueError(f"ERROR: _get_symbols(): Unknown modulation type: {mod_type}, requested!")
 
-        # Here, we apply the effect of the natural voltage divider formed by
-        # the Tx output and Rx input resistances.
-        # (We omit that when calculating the fully terminated channel response,
-        # in keeping w/ common convention.)
-        return array(symbols) * vod * RL / (Rs + RL)
+        return array(symbols) * vod
 
     @cached_property
     def _get_ffe(self):
@@ -1464,8 +1451,12 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
         _z = ch_s2p.s21.z0.flatten()
         if len(_z) == 1:
             _z = _z * np.ones(len(w))
-        # Removing the effect of the resistive divider, as per convention.
-        # (This gets reinserted, in `_get_symbols()`, above.)
+        # `calc_G()` returns the channel's transfer function referenced to the
+        # driver's open-circuit (EMF) amplitude. The `(Rs + RL) / RL` factor
+        # accounts for the natural voltage divider formed by the Tx output and
+        # Rx input resistances, so that `chnl_h` alone captures its effect,
+        # keeping it consistent w/ all the other (derived) pulse responses
+        # (`tx_p`, `ffe_out_p`, `dfe_out_p`, etc.), which are computed from it.
         chnl_H = calc_G(ch_s2p.s21.s.flatten(), Rs, Cs, _z, RL, Cp, w) * (Rs + RL) / RL
         if self.use_window:
             chnl_h = irfft(raised_cosine(chnl_H))

--- a/src/pybert/pybert.py
+++ b/src/pybert/pybert.py
@@ -74,6 +74,7 @@ from pybert.models.fec import FEC_Encoder
 from pybert.results import PyBertData
 from pybert.threads.optimization import OptThread
 from pybert.utility import (
+    calc_G,
     calc_gamma,
     import_channel,
     import_fext,
@@ -1375,8 +1376,6 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
                 file = self.ch_file
                 if not file:
                     raise RuntimeError("'single' is selected but no channel file is specified!")
-                ch_s2p_pre_noninterp = import_freq(file, renumber=self.renumber)
-                self.ch_s2p_pre_noninterp = ch_s2p_pre_noninterp
                 ch_s2p_pre = import_channel(file, ts, f, renumber=self.renumber, lane=self.lane_sel)
                 self.log(str(ch_s2p_pre))
                 H = ch_s2p_pre.s21.s.flatten()
@@ -1449,19 +1448,10 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
         self.ch_s2p = ch_s2p
 
         # Calculate channel impulse response.
-        Zs = Rs / (1 + 1j * w * Rs * Cs)  # Tx termination impedance
-        Zt = RL / (1 + 1j * w * RL * Cp)  # Rx termination impedance
-        ch_s2p_term = ch_s2p.copy()
-        ch_s2p_term_z0 = ch_s2p.z0.copy()
-        ch_s2p_term_z0[:, 0] = Zs
-        ch_s2p_term_z0[:, 1] = Zt
-        ch_s2p_term.renormalize(ch_s2p_term_z0)
-        ch_s2p_term.name = "ch_s2p_term"
-        self.ch_s2p_term = ch_s2p_term
-
-        # We take the transfer function, H, to be a ratio of voltages.
-        # So, we must normalize our (now generalized) S-parameters.
-        chnl_H = ch_s2p_term.s21.s.flatten() * np.sqrt(ch_s2p_term.z0[:, 1] / ch_s2p_term.z0[:, 0])
+        _z = ch_s2p.s21.z0.flatten()
+        if len(_z) == 1:
+            _z = _z * np.ones(len(w))
+        chnl_H = 2 * calc_G(ch_s2p.s21.s.flatten(), Rs, Cs, _z, RL, Cp, w)
         if self.use_window:
             chnl_h = irfft(raised_cosine(chnl_H))
         else:

--- a/src/pybert/pybert.py
+++ b/src/pybert/pybert.py
@@ -663,6 +663,15 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
         mod_type = self.mod_type_
         vod = self.vod
         bits = self.bits
+        Rs = self.rs
+        RL = self.rin
+
+        if self.tx_sel == "ibis":
+            model = self._tx_ibis.model
+            Rs = model.zout * 2
+        if self.rx_sel == "ibis":
+            model = self._rx_ibis.model
+            RL = model.zin * 2
 
         if mod_type == 0:  # NRZ
             symbols = 2 * bits - 1
@@ -693,7 +702,11 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
         else:
             raise ValueError(f"ERROR: _get_symbols(): Unknown modulation type: {mod_type}, requested!")
 
-        return array(symbols) * vod
+        # Here, we apply the effect of the natural voltage divider formed by
+        # the Tx output and Rx input resistances.
+        # (We omit that when calculating the fully terminated channel response,
+        # in keeping w/ common convention.)
+        return array(symbols) * vod * RL / (Rs + RL)
 
     @cached_property
     def _get_ffe(self):
@@ -1451,7 +1464,9 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
         _z = ch_s2p.s21.z0.flatten()
         if len(_z) == 1:
             _z = _z * np.ones(len(w))
-        chnl_H = 2 * calc_G(ch_s2p.s21.s.flatten(), Rs, Cs, _z, RL, Cp, w)
+        # Removing the effect of the resistive divider, as per convention.
+        # (This gets reinserted, in `_get_symbols()`, above.)
+        chnl_H = calc_G(ch_s2p.s21.s.flatten(), Rs, Cs, _z, RL, Cp, w) * (Rs + RL) / RL
         if self.use_window:
             chnl_h = irfft(raised_cosine(chnl_H))
         else:

--- a/src/pybert/pybert.py
+++ b/src/pybert/pybert.py
@@ -1457,7 +1457,7 @@ class PyBERT(HasTraits):  # pylint: disable=too-many-instance-attributes
         # Rx input resistances, so that `chnl_h` alone captures its effect,
         # keeping it consistent w/ all the other (derived) pulse responses
         # (`tx_p`, `ffe_out_p`, `dfe_out_p`, etc.), which are computed from it.
-        chnl_H = calc_G(ch_s2p.s21.s.flatten(), Rs, Cs, _z, RL, Cp, w) * (Rs + RL) / RL
+        chnl_H = calc_G(ch_s2p.s21.s.flatten(), Rs, Cs, _z, RL, Cp, w)
         if self.use_window:
             chnl_h = irfft(raised_cosine(chnl_H))
         else:


### PR DESCRIPTION
- Changed from network renormalization to calling the `pybert.utility.channel.calc_G()` function.

- Renormalization was yielding obviously incorrect results for large values of parasitic capacitance.